### PR TITLE
Added function to get parse time of a line

### DIFF
--- a/skript-plus/! utils/skript.sk
+++ b/skript-plus/! utils/skript.sk
@@ -2,6 +2,14 @@ import:
   ch.njol.skript.Skript
   org.bukkit.Bukkit
   org.bukkit.plugin.PluginDescriptionFile
+  ch.njol.skript.lang.parser.ParserInstance
+  ch.njol.skript.lang.Statement
+
+function skp_get_parse_time(statement: string) :: number:
+  set {_start} to unix timestamp of now
+  set {_parse} to Statement.parse({_statement}, null)
+  set {_finalTime} to (unix timestamp of now) - {_start}
+  return {_finalTime} * 1000
 
 function skp_get_skript_addons() :: strings:
   loop ...Skript.getAddons():


### PR DESCRIPTION
Added a function `skp_get_parse_time(statement: string) :: number:`
in ! utls/skript.sk to get the parse time of a string in miliseconds
Known issues: Errros during the parsing will be logged in console
Statement#parse is supposed to be for conditions and effects only